### PR TITLE
Replace annotations[scheduler.alpha.kubernetes.io/critical-pod] with priorityClassName: system-node-critical in ds.yml

### DIFF
--- a/examples/daemonset.yml
+++ b/examples/daemonset.yml
@@ -12,14 +12,10 @@ spec:
       app: fake-device-plugin
   template:
     metadata:
-      # Mark this pod as a critical add-on; when enabled, the critical add-on scheduler
-      # reserves resources for critical add-on pods so that they can be rescheduled after
-      # a failure.  This annotation works in tandem with the toleration below.
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         app: fake-device-plugin
     spec:
+      priorityClassName: system-node-critical
       nodeSelector:
         fake-device-plugin: 'true'
       tolerations:


### PR DESCRIPTION
The annotation is no longer working on recent versions of K8s, this PR replaces `annotations[scheduler.alpha.kubernetes.io/critical-pod]` with `priorityClassName: system-node-critical` in ds.yml.

```bash
$ kubectl apply -f daemonset.yml                                            
Warning: spec.template.metadata.annotations[scheduler.alpha.kubernetes.io/critical-pod]: non-functional in v1.16+; use the "priorityClassName" field instead
daemonset.apps/fake-device-plugin created
configmap/fake-device-plugin-cm created
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/k8s-dummy-device-plugin/2)
<!-- Reviewable:end -->
